### PR TITLE
Fixes nav links displaying in a column

### DIFF
--- a/css/openucla-style.css
+++ b/css/openucla-style.css
@@ -167,6 +167,9 @@ body {
   100% {
     opacity: 1;
     transform: translateX(0); } }
+@media (min-width: 899px) {
+  .nav-active {
+    flex-direction: row; } }
 /* ******** HEADER ********/
 .ou-header {
   background-size: cover;

--- a/scss/layout/_nav.scss
+++ b/scss/layout/_nav.scss
@@ -79,6 +79,7 @@
   -moz-animation: navslide 0.4s ease-out;
   animation: navslide 0.4s ease-out;
 }
+
 @-webkit-keyframes navslide {
   0% {
     opacity: 0;
@@ -107,5 +108,11 @@
   100% {
     opacity: 1;
     transform: translateX(0);
+  }
+}
+
+@media (min-width: 899px) {
+  .nav-active {
+    flex-direction: row;
   }
 }


### PR DESCRIPTION
Issue: Toggled nav links remain in column alignment when screen resizes up 
Fix: Add media query to change `nav-active` flex-direction in nav.scss